### PR TITLE
claude-code: override our way to 1.0.2

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -15,23 +15,13 @@ let
   userName = "michaelwebb";
   homePath = "/Users/${userName}";
 
-  # 1. cd ~/claude-code;
-  # 2. nix-shell -p nodejs -p node2nix
-  # 3. npm install --package-lock-only @anthropic-ai/claude-code
-  # 4. Update the generated package.json adding name and version
-  # 5. node2nix -l
-  # 6. set npmDepsHash to an empty string and get the real hash from the error message
-  # 7. update the below.
-  claudeCode = pkgs.buildNpmPackage {
-    pname = "claude-code";
+  claude-code = pkgs.claude-code.overrideAttrs rec {
     version = "1.0.2";
-    src = /Users/michaelwebb/claude-code;
+    src = pkgs.fetchzip {
+      url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
+      hash = "sha256-mQv2o9uaOZiZSdkNmLiqJs66fe9fiHfEmrXQZwmME34=";
+    };
     npmDepsHash = "sha256-Diii1tBBzYlB4svlphtu1VAOoijoq9WudxtJFSXXbbE=";
-    dontNpmBuild = true;
-    postInstall = ''
-      mkdir -p "$out/bin"
-      ln -s "$out/lib/node_modules/claude-code/node_modules/@anthropic-ai/claude-code/cli.js" "$out/bin/claude"
-    '';
   };
 in
 {
@@ -75,7 +65,7 @@ in
         # '')
         awscli2
         cachix # Nix build cache
-        claudeCode
+        claude-code
         curl # An old classic
         dbeaver-bin
         fira-code


### PR DESCRIPTION
Try this: the test suite fix for `nodejs_20` is already on `nixos-25.05-darwin` so the only thing we _should_ have to do is override the arguments to `pkgs.claude-code` to tell it to fetch the most recent sources.